### PR TITLE
fix library cleanup in plex auth_dict_unpickle_rce_exploit_tra_2020_32.py

### DIFF
--- a/plex/plex_media_server/auth_dict_unpickle_rce_exploit_tra_2020_32.py
+++ b/plex/plex_media_server/auth_dict_unpickle_rce_exploit_tra_2020_32.py
@@ -69,7 +69,7 @@ def delete_library(target, token, libraryId):
         'X-Plex-Token' : token
     }
 
-    return requests.delete(target, headers=headers)
+    return requests.delete(url, headers=headers)
 
 ### main
 
@@ -125,6 +125,6 @@ restart_service(target, token)
 
 # delete library
 print "Deleting library"
-res = delete_library(target, token, 18)
+res = delete_library(target, token, int(locationId))
 
 print "Done"


### PR DESCRIPTION
@lynerc

Looks like you had a hard-coded library of `18`, and used the wrong url variable on cleanup.  This PR fixes those two issues for a good cleanup routine.